### PR TITLE
Make ts-node optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jest": "^25.1.0",
     "standard": "^14.3.3",
     "ts-jest": "^25.4.0",
+    "ts-node": "^8.8.2",
     "typescript": "^3.8.3"
   },
   "scripts": {
@@ -27,8 +28,15 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "debug": "^4.1.1",
+    "debug": "^4.1.1"
+  },
+  "peerDependencies": {
     "ts-node": "^8.8.2"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=12"

--- a/src/ts-bridge.js
+++ b/src/ts-bridge.js
@@ -3,7 +3,13 @@ const createDebug = require('debug')
 
 const debug = createDebug('ts-bridge')
 
-require('ts-node').register()
+try {
+  require.resolve('ts-node')
+  require('ts-node').register()
+} catch (e) {
+  debug('ts-node not available')
+}
+
 require(path.resolve(__dirname, 'worker'))
 
 // NOTE: ts-node seems to swallow uncaught exceptions,


### PR DESCRIPTION
In ts-bridge, try to resolve the library first. If require.resolve throws an error, then ts-node is not available. This has no effect for JavaScript applications but means TypeScript projects will need to ensure they have ts-node and typescript installed.

In package.json, make ts-node an optional peer dependency.

This fixes runtime errors in JavaScript applications like this:

2021-03-16 02:35:31+0000: Error: Worker 1 initialization timed out
2021-03-16 02:35:31+0000:     at Timeout._onTimeout (/opt/app/node_modules/thread-puddle/lib/index.js:225:20)
2021-03-16 02:35:31+0000:     at listOnTimeout (internal/timers.js:549:17)
2021-03-16 02:35:31+0000:     at processTimers (internal/timers.js:492:7)

Fixes #6.