### PR TITLE
Chore/production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Version 0.4.0
   - Basic Callback Functions #21
     - Workers can now implement EventEmitter behaviour
-    - Worker paths can now be relative
-    - ts-node is now `transpile-only` per default
-    - Allows chaining (resolves to the proxy when the worker returns itself)
-    - Upgrade all dev dependencies
-    - Improved typing
+  - Worker paths can now be relative
+  - ts-node is now `transpile-only` per default #21
+  - Allows chaining (resolves to the proxy when the worker returns itself)
+  - Upgrade all dev dependencies
+  - Improved typing
+  - Max Queue Size #29
+    - Subsequent calls will be rejected when max queue size is reached,
+    until the queue is emptied below max again.
 
 ## Version 0.3.2
   - Stricter and fixed types #16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
     - Subsequent calls will be rejected when max queue size is reached,
     until the queue is emptied below max again.
   - Refill
-    - can auto refill the pool when workers unexpectedly exit
-    - can manually refill the pool whenever
+    - automatically refill pool when workers exit via `autoRefill: true` pool option
+    - manually refill pool whenever via `worker.pool.refill()`
+  - Drain (graceful shutdown)
+    - Wait until all calls are done and workers are idle, then terminate, via `worker.pool.drain()`
 
 ## Version 0.3.2
   - Stricter and fixed types #16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - Max Queue Size #29
     - Subsequent calls will be rejected when max queue size is reached,
     until the queue is emptied below max again.
+  - Refill
+    - can auto refill the pool when workers unexpectedly exit
+    - can manually refill the pool whenever
 
 ## Version 0.3.2
   - Stricter and fixed types #16

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Arguments:
   - `startupTimeout` - if a worker thread cannot be started within this timout in milliseconds, the pool creation will fail and reject with a timout error. Defaults to `30000`.
   - `typecheck` - In development `ts-node` is used, which by default runs `transpile-only` mode. To get type checks, set this to `true`.
   - `maxQueueSize` - When filled up with waiting calls, will reject all subsequent calls, until emptied to below max again. Defaults to `1000`
+  - `autoRefill` - Automatically fills up the pool with workers until `size` is reached when workers unexpectedly exit. Default `false`
 
 If the pool size is `> 1`, method calls will be forwarded to the next available worker. If all workers are busy, the method calls will be queued. A worker will handle one method call at any time only.
 
@@ -142,6 +143,10 @@ Will call the given `method` on all workers, as soon as they become available. R
 ### `worker.pool.terminate()`
 
 Terminates the pool and all worker threads in it. Trying to call methods in the pool afterwards, will result in an rejection.
+
+### `worker.pool.refill()`
+
+Fills up the pool with workers until `size` is reached. Can be used to manually decide wether to refill or terminate.
 
 ### `worker.pool.size`
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Arguments:
   - `startupTimeout` - if a worker thread cannot be started within this timout in milliseconds, the pool creation will fail and reject with a timout error. Defaults to `30000`.
   - `typecheck` - In development `ts-node` is used, which by default runs `transpile-only` mode. To get type checks, set this to `true`.
   - `maxQueueSize` - When filled up with waiting calls, will reject all subsequent calls, until emptied to below max again. Defaults to `1000`
-  - `autoRefill` - Automatically fills up the pool with workers until `size` is reached when workers unexpectedly exit. Default `false`
+  - `autoRefill` - Automatically fills up the pool with workers until `size` is reached when workers unexpectedly exit. Defaults to `false`.
 
 If the pool size is `> 1`, method calls will be forwarded to the next available worker. If all workers are busy, the method calls will be queued. A worker will handle one method call at any time only.
 
@@ -104,7 +104,7 @@ On the Proxy Object returned from `createThreadPool`, you can call any method wh
 - `method` - Must match a method name exported from the worker module.
 - `arguments` - Arbitrary number of arguments forwarded to the method call in the worker thread.
 
-`Arguments` are transferred to the worker thread via [`postMessage`](https://nodejs.org/dist/latest-v12.x/docs/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist), compatible with the [HTML structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). If you want to move arguments of type `ArrayBuffer` or `MessageChannel` instead of copying them, you can use the `withTransfer` helper.
+`Arguments` are transferred to the worker thread via [`postMessage`](https://nodejs.org/dist/latest-v12.x/docs/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist), compatible with the [HTML structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). If you want to move arguments of type `ArrayBuffer` or `MessageChannel` instead of copying them, you can use the [`withTransfer`](#withtransfervalue-transferlist) helper.
 
 `Arguments` can contain a __`function`__ (__callback__) in the first level, which will be callable from the thread via a reference, but be executed on the main thread.
 __However__, the result of the callback is currently __not__ transfered back to the thread. It is possible to implement a worker thread with an `EventEmitter` though, see the [eventemitter example](./examples/ts-eventemitter/). Callback errors will throw an `unhandled exception` if no error listener is attached to the pool `callback:error` event like `worker.pool.on('callback:error', () => ...)`.
@@ -148,6 +148,10 @@ Terminates the pool and all worker threads in it. Trying to call methods in the 
 
 Fills up the pool with workers until `size` is reached. Can be used to manually decide wether to refill or terminate.
 
+### `worker.pool.drain()`
+
+Waits until all calls are handled and threads are idle, then terminates all threads.
+
 ### `worker.pool.size`
 
 The number of worker threads in the pool.
@@ -158,7 +162,7 @@ Wether or not the pool was terminated.
 
 ### `withTransfer(value, [transferList])`
 
-This helper can be used **bi-directional**, to transfer values to a worker thread as method call argument(s), or to transfer values from a worker thread method.
+This helper can be used **bi-directional**, to transfer values to a worker thread as method call argument(s), or to transfer return values from a worker thread method.
 
 Arguments:
 
@@ -202,7 +206,7 @@ Forwards errors that are emitted for a specific worker in the pool. When a worke
 
 #### `exit`
 
-Forwards exit events that are emitted for a specific worker in the pool, addind the `threadId` as second argument.
+Forwards exit events that are emitted for a specific worker in the pool, adding the `threadId` as second argument.
 
 ## Debug
 

--- a/examples/benchmark/main.ts
+++ b/examples/benchmark/main.ts
@@ -1,0 +1,61 @@
+import { createThreadPool } from '../../lib'
+import { CalcWorker } from './puddle-worker'
+import { MessageChannel, MessagePort, Worker, WorkerOptions } from "worker_threads"
+import path from 'path'
+
+const ITERATIONS = 100000
+
+async function start () {
+  // Puddle
+  const worker = await createThreadPool<CalcWorker>('./puddle-worker')
+  const puddleStart = Date.now()
+  
+  for (let i = 0; i < ITERATIONS; i++) {
+    await worker.add(1, 2) 
+  }
+
+  worker.pool.terminate()
+
+  const duration = Date.now() - puddleStart
+  const perCallAvg = duration / ITERATIONS
+
+  console.log('Puddle duration:', duration)
+  console.log('Puddle avg per call:', perCallAvg)
+  
+  // Raw
+  const workerPath = path.resolve(__dirname, './raw-worker.ts')
+  const workerString = `require('ts-node/register/transpile-only')\nrequire('${workerPath}')`
+  const rawWorker = new Worker(workerString, { eval: true })
+  let count = 0
+  let rawStart = 0
+  
+  const done = () => {
+    if (count < ITERATIONS) {
+      return run()
+    }
+
+    rawWorker.terminate()
+
+    const duration = Date.now() - rawStart
+    const perCallAvg = duration / ITERATIONS
+  
+    console.log('Raw duration:', duration)
+    console.log('Raw avg per call:', perCallAvg)
+  }
+
+  const run = () => {
+    count += 1
+    rawWorker.postMessage({ action: 'calc', a: 1, b: 2 })
+  }
+
+  rawWorker.on('message', (msg: any) => {
+    if (msg.action === 'result') {
+      done()
+    } else if (msg.action === 'ready') {
+      rawStart = Date.now()
+      run()
+    }
+  })
+}
+
+start()

--- a/examples/benchmark/main.ts
+++ b/examples/benchmark/main.ts
@@ -5,9 +5,12 @@ import path from 'path'
 
 const ITERATIONS = 100000
 
+/**
+ * Checking the pure roundtrip overhead
+ */
 async function start () {
   // Puddle
-  const worker = await createThreadPool<CalcWorker>('./puddle-worker')
+  const worker = await createThreadPool<CalcWorker>('./puddle-worker', { size: 2 })
   const puddleStart = Date.now()
   
   for (let i = 0; i < ITERATIONS; i++) {

--- a/examples/benchmark/puddle-worker.ts
+++ b/examples/benchmark/puddle-worker.ts
@@ -1,0 +1,7 @@
+export class CalcWorker {
+  add(a, b): number {
+    return a + b
+  }
+}
+
+export default new CalcWorker()

--- a/examples/benchmark/raw-worker.ts
+++ b/examples/benchmark/raw-worker.ts
@@ -1,0 +1,14 @@
+import { parentPort } from 'worker_threads'
+
+if (!parentPort) {
+  throw new Error('No parentPort available')
+}
+
+parentPort.on('message', (msg: any) => {
+  if (msg.action === 'calc') {
+    const result = msg.a + msg.back
+    parentPort?.postMessage({ action: 'result', result })
+  }
+})
+
+parentPort.postMessage({ action: 'ready' })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thread-puddle",
   "description": "Turn any module into a worker thread",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-rc.1",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "thread-pool",
     "worker",
     "worker-pool",
-    "proxy object"
+    "proxy object",
+    "queue"
   ]
 }

--- a/src/WorkerThread.ts
+++ b/src/WorkerThread.ts
@@ -70,6 +70,38 @@ export class WorkerThread extends EventEmitter {
       this.emit('error', err, id)
     })
 
+    // TODO: Handle message error. 
+    // Rare and possibly fatal as promises may never be resolved.
+    // Note: This happens when trying to receive an array buffer that has already been detached.
+    port2.on('messageerror', (err: Error) => {
+      // Consider pool termination and reject all open promises
+    })
+
+    const messageHandler = (msg: BaseThreadMessage) => {
+      this.emit('message', msg, id)
+
+      const handled = callableStore.handleMessage(msg, id)
+
+      if (!handled) {
+        throw new Error(`Unknown worker pool action "${(msg as BaseThreadMessage).action}"`)
+      }
+    }
+
+    const initHandler = (msg: BaseThreadMessage) => {
+      if (isThreadReadyMessage(msg)) {
+        port2.on('message', messageHandler)
+        port2.off('message', initHandler)
+        this.onReady()
+      } else if (isThreadStartupErrorMessage(msg)) {
+        // TODO: WTH... why is msg type never?
+        const err = new Error((msg as ThreadErrorMessage).message)
+        err.stack = (msg as ThreadErrorMessage).stack
+        this.emit('startup-error', err, id)
+        port2.off('message', initHandler)
+      }
+    }
+    port2.on('message', initHandler)
+
     const initMsg: InitMessage = {
       action: MainMessageAction.INIT,
       workerPath: resolvedWorkerPath,
@@ -79,39 +111,6 @@ export class WorkerThread extends EventEmitter {
     }
 
     worker.postMessage(initMsg, [port1])
-
-    // TODO: Handle message error. 
-    // Rare and possibly fatal as promises may never be resolved.
-    // Note: This happens when trying to receive an array buffer that has already been detached.
-    port2.on('messageerror', (err: Error) => {
-      // Consider pool termination and reject all open promises
-    })
-
-    port2.on('message', (
-      msg: BaseThreadMessage
-    ) => {
-      this.emit('message', msg, id)
-
-      const handled = callableStore.handleMessage(msg, id)
-
-      if (isThreadCallbackMessage(msg) || isThreadErrorMessage(msg)) {
-        this.onReady()
-        return
-      } else if (isThreadReadyMessage(msg)) {
-        this.onReady()
-        return
-      } else if (isThreadStartupErrorMessage(msg)) {
-        // TODO: WTH... why is msg type never?
-        const err = new Error((msg as ThreadErrorMessage).message)
-        err.stack = (msg as ThreadErrorMessage).stack
-        this.emit('startup-error', err, id)
-        return
-      }
-
-      if (!handled) {
-        throw new Error(`Unknown worker pool action "${(msg as BaseThreadMessage).action}"`)
-      }
-    })
   }
 
   terminate() {
@@ -146,7 +145,9 @@ export class WorkerThread extends EventEmitter {
     this.debug('calling %s on worker %d', key, this.id)
     this.busy = true
 
-    const { msg, transferables } = this.callableStore.createCallMessage(key, args, { resolve, reject })
+    const { msg, transferables } = this.callableStore.createCallMessage(key, args, { 
+      resolve, reject, done: () => this.onReady() 
+    })
 
     this.port.postMessage(msg, transferables)
   }

--- a/src/WorkerThread.ts
+++ b/src/WorkerThread.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "stream"
 import { MessageChannel, MessagePort, Worker, WorkerOptions } from "worker_threads"
 import { CallableStore } from "./components/callable-store"
 import { ThreadId, ThreadMethodKey } from "./types/general"
-import { BaseThreadMessage, InitMessage, isThreadCallbackMessage, isThreadErrorMessage, isThreadReadyMessage, isThreadStartupErrorMessage, MainMessageAction, ThreadErrorMessage } from "./types/messages"
+import { BaseThreadMessage, InitMessage, isThreadReadyMessage, isThreadStartupErrorMessage, MainMessageAction, ThreadErrorMessage } from "./types/messages"
 
 export interface QueuedCall {
   key: ThreadMethodKey

--- a/src/WorkerThread.ts
+++ b/src/WorkerThread.ts
@@ -18,7 +18,7 @@ export class WorkerThread extends EventEmitter {
   private worker: Worker
   public readonly port: MessagePort
   public error: Error | boolean = false
-  private callQueue: QueuedCall[] = []
+  public callQueue: QueuedCall[] = []
   private busy: boolean = true
   private isTerminated: boolean = false
 

--- a/src/__tests__/workers/callback.ts
+++ b/src/__tests__/workers/callback.ts
@@ -15,6 +15,10 @@ export class WorkerWithCallback {
       callback(result)
     }, timeout)
   }
+
+  triggerExit() {
+    setTimeout(() => process.exit(), 25)
+  }
 }
 
 export default new WorkerWithCallback()

--- a/src/components/request-queue.ts
+++ b/src/components/request-queue.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from 'events';
+import { ThreadRequest } from '..';
+
+export class RequestQueue extends EventEmitter {
+  private threadRequests: ThreadRequest[] = []
+
+  constructor() {
+    super()
+  }
+
+  size() {
+    return this.threadRequests.length
+  }
+
+  push(request: ThreadRequest): void {
+    this.threadRequests.push(request)
+  }
+
+  hasPending(): boolean {
+    return this.threadRequests.length > 0
+  }
+
+  next(): ThreadRequest | undefined {
+    const request = this.threadRequests.shift()
+    this.emit('empty')
+    return request
+  }
+
+  rejectAll(err: any) {
+    for (const workerRequest of this.threadRequests) {
+      workerRequest.reject(err)
+    }
+  }
+}

--- a/src/gc.spec.ts
+++ b/src/gc.spec.ts
@@ -4,6 +4,7 @@ import { createThreadPool } from './index'
 import debug from 'debug'
 import { WorkerWithCallback } from './__tests__/workers/callback'
 import { isThreadFreeFunctionMessage, ThreadMessageAction } from './types/messages'
+import { WorkerThread } from './WorkerThread'
 
 debug.enabled('puddle')
 
@@ -40,7 +41,9 @@ describe('Garbage Collections', () => {
       functionId: expect.any(Number),
       key: expect.any(String)
     })
-    const numberOfStoredMethods = worker.pool.callbacks.get('withCallback')?.size
+
+    const thread: WorkerThread = worker.pool.threads.values().next().value
+    const numberOfStoredMethods = thread.callableStore.callbacks.get('withCallback')?.size
     expect(numberOfStoredMethods).toBeLessThan(callTimes / 2)
   }, 30000)
 })

--- a/src/thread-pool.spec.ts
+++ b/src/thread-pool.spec.ts
@@ -10,6 +10,7 @@ import { WorkerWithEmitter } from './__tests__/workers/eventemitter'
 import { ChainWorkerClass } from './__tests__/workers/this'
 import BasicWorker from './__tests__/workers/basic'
 import { ValidWorkerModule } from './__tests__/workers/module'
+import { WorkerThread } from './WorkerThread'
 
 debug.enabled('puddle')
 
@@ -411,9 +412,13 @@ describe('Error Handling', () => {
       worker.waitForUncaughtException(100).catch((err: Error) => err)
     ])
     const mapBy = countBy(result.map((err) => err.message))
-    
-    expect(Object.keys(mapBy)).toHaveLength(2)
-    expect(mapBy).toHaveProperty('Worker failure', 2)
+
+    expect(Object.keys(mapBy)).toHaveLength(3)
+    expect(mapBy).toEqual({
+      'Worker failure': 1,
+      'Worker thread exited before resolving': 1,
+      'All workers exited before resolving (use an error event handler or DEBUG=puddle:*)': 2
+    })
     
     worker.pool.terminate()
   })
@@ -479,15 +484,16 @@ describe('Error Handling', () => {
       worker.waitForUnhandledRejection(100).catch((err: Error) => err)
     ])
     const mapBy = countBy(result.map((err) => err.message))
-    
-    expect(Object.keys(mapBy)).toHaveLength(2)
-    expect(mapBy).toHaveProperty('Worker Promise failure', 2)
+
+    expect(Object.keys(mapBy)).toHaveLength(3)
+    expect(mapBy).toEqual({
+      'Worker Promise failure': 1,
+      'Worker thread exited before resolving': 1,
+      'All workers exited before resolving (use an error event handler or DEBUG=puddle:*)': 2
+    })
     
     worker.pool.terminate()
   })
-
-  it.todo('[Proposal] allows to manually respawn workers after error')
-  it.todo('[Proposal] allows to manually respawn workers after exit')
 })
 
 describe('ts-bridge', () => {
@@ -731,8 +737,28 @@ describe('Callbacks', () => {
     worker.pool.terminate()
   })
 
-  it.todo('frees main functions when threads holding references exit')
-  it.todo('does not handle callbacks when already terminated')
+  it('frees main functions when threads holding references exit', async () => {
+    const worker = await createThreadPool<WorkerWithCallback>('./__tests__/workers/callback')
+
+    const fn = () => {}
+    worker.withCallback(10, 20, fn)
+
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 100))
+
+    const thread: WorkerThread = worker.pool.threads.values().next().value
+    let numberOfStoredMethods = thread.callableStore.callbacks.get('withCallback')?.size
+    expect(numberOfStoredMethods).toEqual(1)
+
+    worker.triggerExit()
+
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 100))
+    
+    const callbacks = thread.callableStore.callbacks.get('withCallback')
+    expect(callbacks).toEqual(undefined)
+
+    worker.pool.terminate()
+  })
+
   it.todo('can transfer objects with callback')
 })
 

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,4 +1,4 @@
 export type ThreadId = number
-export type CallbackId = number
+export type CallableId = number
 export type FunctionId = number
 export type ThreadMethodKey = string | number

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,5 +1,5 @@
 import { MessagePort } from "worker_threads"
-import { CallbackId, ThreadId, ThreadMethodKey } from "./general"
+import { CallableId, ThreadId, ThreadMethodKey } from "./general"
 
 // Sent by main
 export enum MainMessageAction {
@@ -13,7 +13,7 @@ export type BaseMainMessage = {
 
 export type CallMessage = BaseMainMessage & {
   key: ThreadMethodKey
-  callbackId: number
+  callableId: number
   args: any
   argFunctionPositions: number[]
 }
@@ -42,23 +42,23 @@ export type BaseThreadMessage = {
 export type ThreadReadyMessage = BaseThreadMessage
 
 export type ThreadCallbackMessage = BaseThreadMessage & {
-  callbackId: CallbackId
+  callableId: CallableId
   result: any
 }
 
 export type ThreadFunctionMessage = BaseThreadMessage & {
-  functionId: CallbackId
+  functionId: CallableId
   key: ThreadMethodKey
   args: any[]
 }
 
 export type ThreadFreeFunctionMessage = BaseThreadMessage & {
-  functionId: CallbackId
+  functionId: CallableId
   key: ThreadMethodKey
 }
 
 export type ThreadErrorMessage = BaseThreadMessage & {
-  callbackId: CallbackId
+  callableId: CallableId
   message: string
   stack: string
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,7 @@ import {
   BaseMainMessage,
   CallMessage,
   InitMessage,
+  MainMessageAction,
   ThreadCallbackMessage,
   ThreadErrorMessage,
   ThreadFreeFunctionMessage,
@@ -82,8 +83,8 @@ parentPort.once('message', async (msg: InitMessage) => {
 
   port.on('message', async (msg: BaseMainMessage) => {
     switch (msg.action) {
-      case 'call': {
-        const { key, args, callbackId, argFunctionPositions } = msg as CallMessage
+      case MainMessageAction.CALL: {
+        const { key, args, callableId, argFunctionPositions } = msg as CallMessage
         debug('calling worker thread method %s', key)
 
         try {
@@ -121,7 +122,7 @@ parentPort.once('message', async (msg: InitMessage) => {
           if (result instanceof TransferableValue) {
             const resultMsg: ThreadCallbackMessage = {
               action: ThreadMessageAction.RESOLVE,
-              callbackId,
+              callableId,
               result: result.obj
             }
             
@@ -129,7 +130,7 @@ parentPort.once('message', async (msg: InitMessage) => {
           } else {
             const resultMsg: ThreadCallbackMessage = { 
               action: ThreadMessageAction.RESOLVE, 
-              callbackId, 
+              callableId, 
               result 
             }
             port.postMessage(resultMsg)
@@ -138,7 +139,7 @@ parentPort.once('message', async (msg: InitMessage) => {
           debug(message)
           const resultMsg: ThreadErrorMessage = { 
             action: ThreadMessageAction.REJECT, 
-            callbackId, 
+            callableId, 
             message: message as string, 
             stack: stack as string 
           }


### PR DESCRIPTION
- Refill
  - automatically refill pool when workers exit via `autoRefill: true` pool option
  - manually refill pool whenever via `worker.pool.refill()`
- Drain (graceful shutdown)
  - Wait until all calls are done and workers are idle, then terminate, via `worker.pool.drain()`
- Frees callbacks on main thread when a worker exits